### PR TITLE
Fix TX battery text vertical centering in top bar

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -71,3 +71,11 @@ files["tests/spec/release_spec.lua"] = {
 files["tests/spec/layout_grid_spec.lua"] = {
   globals = { "Bitmap" },
 }
+-- Temporarily overrides lcd.sizeText with a stub that returns a distinct
+-- height, to prove drawTxBattery() centers on sizeText()'s real
+-- measurement rather than a hardcoded guess (issue #74 regression test) --
+-- needs write access to the lcd global mock_edgetx.lua already installed,
+-- same as the Bitmap overrides above.
+files["tests/spec/topbar_spec.lua"] = {
+  globals = { "lcd" },
+}

--- a/SCRIPTS/WIDGETS/FPVDASH/render/topbar.lua
+++ b/SCRIPTS/WIDGETS/FPVDASH/render/topbar.lua
@@ -505,7 +505,8 @@ local function drawTxBattery(rect, txV, txState)
     textX = groupX + TX_BATTERY_ICON_W + TX_ICON_TEXT_GAP
   end
 
-  local textY = centerStart(rect.y, rect.h, TX_TEXT_H)
+  local _, textH = sizeText(txText, SMLSIZE, TX_TEXT_CHAR_W, TX_TEXT_H)
+  local textY = centerStart(rect.y, rect.h, textH)
   drawShadowText(textX, textY, txText, SMLSIZE, txColor)
 end
 

--- a/tests/spec/topbar_spec.lua
+++ b/tests/spec/topbar_spec.lua
@@ -68,6 +68,38 @@ return function(t, mock, paths)
       end)
     end)
 
+    t.it("vertically centers the TX battery text using sizeText()'s measured height, not a hardcoded guess (issue #74)", function()
+      mock.withInstall({ sensors = { ["tx-voltage"] = { value = 7.6 } } }, function()
+        -- Override the mock's SMLSIZE height so it disagrees with
+        -- topbar.lua's TX_TEXT_H=8 fallback guess. If drawTxBattery()
+        -- still centered on that hardcoded guess instead of calling
+        -- sizeText() (the bug in issue #74), the asserted y below would
+        -- be 14 (centerStart(0, 36, 8)) instead of 7.
+        local realSizeText = lcd.sizeText
+        lcd.sizeText = function(text, flags)
+          if (flags or 0) == 0 then
+            return #tostring(text or "") * 5, 21
+          end
+          return realSizeText(text, flags)
+        end
+
+        local topbar = paths.loadWidgetModule("render/topbar.lua")
+        topbar.draw(BOUNDS, { connected = false }, nil, THEME)
+
+        -- drawShadowText() draws two passes -- a shadow at (x+1, y+1),
+        -- then the real text at (x, y) -- so take the last "7.6V" call
+        -- (the real text), not the first (the shadow, off by 1).
+        local txTextY = nil
+        for _, call in ipairs(mock.lcdCalls or {}) do
+          if call.name == "drawText" and call[3] == "7.6V" then
+            txTextY = call[2]
+          end
+        end
+
+        t.assertEqual(txTextY, 7)
+      end)
+    end)
+
     t.it("renders without error across repeated calls and a theme change (icon reload path)", function()
       mock.withInstall({ sensors = {} }, function()
         local topbar = paths.loadWidgetModule("render/topbar.lua")


### PR DESCRIPTION
## Summary
- `drawTxBattery()` in `render/topbar.lua` centered the TX battery voltage text on a hardcoded `TX_TEXT_H = 8` guess instead of the real glyph height from `sizeText()` — the same bug class already fixed for the model-name and date/time cells.
- Now measures the actual height via `sizeText()` (falling back to the same guess only when `lcd.sizeText` is unavailable), matching the pattern used elsewhere in this file.

Fixes #74

## Test plan
- [x] `lua tests/run.lua` — 162/162 passing, including a new regression test that overrides the mock's `lcd.sizeText` to return a height that disagrees with the old hardcoded constant, asserting the text now centers on the measured height instead.
- [x] Visual confirmation in EdgeTX Companion / on hardware — confirmed by user

🤖 Generated with [Claude Code](https://claude.com/claude-code)